### PR TITLE
Improve missing library handling

### DIFF
--- a/HCNetSDK/HCNetSDK.py
+++ b/HCNetSDK/HCNetSDK.py
@@ -58,7 +58,8 @@ class NetClient(metaclass=Singleton):
             cls.sdk = load_library(netsdkdllpath)
             cls.play_sdk = load_library(playsdkdllpath)
         except OSError as e:
-            print('动态库加载失败')
+            print('动态库加载失败:', e)
+            raise
 
         cls.coding_format = 'gbk' if sys_platform == 'windows' else 'utf-8'
 


### PR DESCRIPTION
## Summary
- raise an exception if HCNetSDK dynamic libraries fail to load

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_688ba1c0320883249f7d68a131d982cd