### PR TITLE
Improve error handling for missing dynamic libs

### DIFF
--- a/HCNetSDK/HCNetSDK.py
+++ b/HCNetSDK/HCNetSDK.py
@@ -58,7 +58,7 @@ class NetClient(metaclass=Singleton):
             cls.sdk = load_library(netsdkdllpath)
             cls.play_sdk = load_library(playsdkdllpath)
         except OSError as e:
-            print('动态库加载失败')
+            raise RuntimeError(f"Failed to load dynamic libraries: {e}") from e
 
         cls.coding_format = 'gbk' if sys_platform == 'windows' else 'utf-8'
 


### PR DESCRIPTION
## Summary
- raise a RuntimeError when HCNetSDK dynamic libraries fail to load

## Testing
- `python3 server.py` *(fails: missing `libhcnetsdk.so`)*

------
https://chatgpt.com/codex/tasks/task_e_688ba1c0320883249f7d68a131d982cd